### PR TITLE
chore(deps): bump all wormhole deps and add dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Always bump the lower bound in package.json to match the new version,
+    # preventing version drift within groups (e.g. ^4.0.10 staying behind ^4.0.12)
+    versioning-strategy: increase
     # Only update Wormhole dependencies
     allow:
       - dependency-name: "@wormhole-foundation/*"
+    # Group NTT packages together (released together)
+    groups:
+      wormhole-ntt:
+        patterns:
+          - "@wormhole-foundation/sdk-*-ntt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
 				"@solana-developers/helpers": "^2.8.0",
 				"@solana/spl-token": "^0.4.13",
 				"@solana/web3.js": "^1.98.0",
-				"@wormhole-foundation/sdk": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.8.0",
-				"@wormhole-foundation/sdk-solana-ntt": "4.0.10",
+				"@wormhole-foundation/sdk": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1",
+				"@wormhole-foundation/sdk-solana-ntt": "4.0.16",
 				"dotenv": "^16.4.7"
 			},
 			"devDependencies": {
@@ -68,9 +68,9 @@
 			}
 		},
 		"node_modules/@aptos-labs/aptos-client": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-2.1.0.tgz",
-			"integrity": "sha512-ttdY0qclRvbYAAwzijkFeipuqTfLFJnoXlNIm58tIw3DKhIlfYdR6iLqTeCpI23oOPghnO99FZecej/0MTrtuA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-2.2.0.tgz",
+			"integrity": "sha512-lYgHI8ehgD+Ykhix0IwzLaTCknHp1KNmExbq2bPZk8IeTwQg79D5BOkD46MjW0jGbJbl+J/RBtVF9vM7Te/hWA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20.0.0"
@@ -83,6 +83,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-2.0.1.tgz",
 			"integrity": "sha512-k39Ks+qNcWxWujQrixMaV3ZIO8G9/qzIpDuV7+Td12GWNxXxKze5BqD6pFI3Q1iwI4mw65v1yxTi/jt5ted39Q==",
+			"deprecated": "This version is deprecated, please upgrade to 5.2.1, or the latest version",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aptos-labs/aptos-cli": "^1.0.2",
@@ -409,9 +410,9 @@
 			}
 		},
 		"node_modules/@injectivelabs/core-proto-ts-v2": {
-			"version": "1.17.3",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts-v2/-/core-proto-ts-v2-1.17.3.tgz",
-			"integrity": "sha512-AyMh+Ms9IOoM7GmxxoB924rjI4r4zwCF/mRx40aN1Ykg+vzp2CfjMkR+AoyQ2b15f1iiY7GnO7l4BoHw77R/Hw==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts-v2/-/core-proto-ts-v2-1.18.0.tgz",
+			"integrity": "sha512-jXxwaE0cdFVEtRgamQwYtSfDNs1ZCWPM4HimJIufpMVG1NVrZiFUMCXtfm9C9dsBMverBMq+Py4uK0Xy7UJiEg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -420,9 +421,9 @@
 			}
 		},
 		"node_modules/@injectivelabs/exceptions": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.17.6.tgz",
-			"integrity": "sha512-QVgaQMhaM4/2MOOth32B6ZwhtSQCVkwwFzWpIFJU8UsAkripoXXtjxseHSDJ+yzIFHElcf4afzWiWpsZWsiv2w==",
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.18.8.tgz",
+			"integrity": "sha512-SXe6bCXNvKcjJwKrRRMX6CBX7/Td4P0PHmMGAFbYzneYTMQpeP4XWDy0OxiXoxnHtT0YF2cHQBTSL2hdOyO1rg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"http-status-codes": "^2.3.0"
@@ -460,9 +461,9 @@
 			}
 		},
 		"node_modules/@injectivelabs/indexer-proto-ts-v2": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.17.6.tgz",
-			"integrity": "sha512-r38sgpOpvxy53FDZwKo6pBBsCRRRfIqlBrFiohkKxBouDY8O2cUtCOYPJ6kMTZsU8ILWPbom/BvJnUtLNrq5/Q==",
+			"version": "1.18.6",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.18.6.tgz",
+			"integrity": "sha512-RknQB7tDQKDXGuQw/oGGoG95X7D+Hrwj9wcgDo4n22W9dnJsHqdWx+wUJgrvezGmmQBr9jvbcGRj+yPJw6E21g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -482,12 +483,12 @@
 			}
 		},
 		"node_modules/@injectivelabs/networks": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.17.6.tgz",
-			"integrity": "sha512-KorCgskim/bYZ89BklbJJXSL0i0NeOO8gTbXT6aKyZKxWESyYmccaM96NEBji2HVa03hADc9/Ghd/JOWQnfEtQ==",
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.18.8.tgz",
+			"integrity": "sha512-VTh9cKPfFV1Zd4WXspAnEeRt7ENmdQf5pApeJkRpgBNxkZpInSwe/hQhMKi4EDPPF7TaMATg9VOn4wxRorI3fQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@injectivelabs/ts-types": "1.17.6"
+				"@injectivelabs/ts-types": "1.18.8"
 			}
 		},
 		"node_modules/@injectivelabs/olp-proto-ts-v2": {
@@ -502,26 +503,26 @@
 			}
 		},
 		"node_modules/@injectivelabs/sdk-ts": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.17.6.tgz",
-			"integrity": "sha512-9TWzaRytSeP5anlPGw64y1M9M8IDbJbK/lOLsVyPC9ftAuX6/jN4X6fLT5f8GlDIzV8S1wRqTy2Xu4F5/wwmcA==",
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.18.8.tgz",
+			"integrity": "sha512-ouIQMzdY39cd1/jOlr8+jz8kywA0o5tlL2m+GJEtcek2wgBZH7Gsn/5oiANcFoxsIVggABTEnek9k7UYIim4Tg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cosmjs/amino": "0.33.0",
 				"@cosmjs/proto-signing": "0.33.0",
 				"@cosmjs/stargate": "0.33.0",
 				"@injectivelabs/abacus-proto-ts-v2": "1.17.4",
-				"@injectivelabs/core-proto-ts-v2": "1.17.3",
-				"@injectivelabs/exceptions": "1.17.6",
+				"@injectivelabs/core-proto-ts-v2": "1.18.0",
+				"@injectivelabs/exceptions": "1.18.8",
 				"@injectivelabs/grpc-web": "^0.0.1",
 				"@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
 				"@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-				"@injectivelabs/indexer-proto-ts-v2": "1.17.6",
+				"@injectivelabs/indexer-proto-ts-v2": "1.18.6",
 				"@injectivelabs/mito-proto-ts-v2": "1.17.3",
-				"@injectivelabs/networks": "1.17.6",
+				"@injectivelabs/networks": "1.18.8",
 				"@injectivelabs/olp-proto-ts-v2": "1.17.6",
-				"@injectivelabs/ts-types": "1.17.6",
-				"@injectivelabs/utils": "1.17.6",
+				"@injectivelabs/ts-types": "1.18.8",
+				"@injectivelabs/utils": "1.18.8",
 				"@noble/curves": "^1.9.0",
 				"@noble/hashes": "^1.8.0",
 				"@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -536,7 +537,8 @@
 				"http-status-codes": "^2.3.0",
 				"rxjs": "7.8.2",
 				"snakecase-keys": "^5.4.1",
-				"viem": "^2.41.2"
+				"viem": "^2.41.2",
+				"ws": "^8.18.0"
 			}
 		},
 		"node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/amino": {
@@ -623,6 +625,27 @@
 				"xstream": "^11.14.0"
 			}
 		},
+		"node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/socket/node_modules/ws": {
+			"version": "7.5.10",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/stargate": {
 			"version": "0.33.0",
 			"resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.0.tgz",
@@ -678,21 +701,42 @@
 			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"license": "MIT"
 		},
+		"node_modules/@injectivelabs/sdk-ts/node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@injectivelabs/ts-types": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.17.6.tgz",
-			"integrity": "sha512-/cQGcSNkVIpYqP9SwC4DEKzrkf0QicpTKUEILVRAvfOkkGBiZzUwywCVJkJAp/89ubI/5mBQyhfIBmjUjDA+9Q==",
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.18.8.tgz",
+			"integrity": "sha512-6P+abdWhoH7v40aUI3dvWHhrDXDvzyRqbSLFJOd6N94W8Ihiv5z12wPhOsTJsqTR2fxP6uOUuDz/jnPt/bHNqQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@injectivelabs/utils": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.17.6.tgz",
-			"integrity": "sha512-FDa0F2FNZEblXKYzJn2/9aMNs0vsOAo+5HGEPj7lurlovbxvDw766SNswaMKkCsB74AXyqxilXRjpGmnGHfU3w==",
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.18.8.tgz",
+			"integrity": "sha512-LLzVG08fvumUczzQtcSp16Yb+G3i/IcDXbMinuXszECynDI0tT6ICvNLt3kn8d8GwWpUmxiNraD113wz8w8naA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@injectivelabs/exceptions": "1.17.6",
-				"@injectivelabs/networks": "1.17.6",
-				"@injectivelabs/ts-types": "1.17.6",
+				"@injectivelabs/exceptions": "1.18.8",
+				"@injectivelabs/networks": "1.18.8",
+				"@injectivelabs/ts-types": "1.18.8",
 				"axios": "^1.13.2",
 				"bignumber.js": "^9.3.1",
 				"http-status-codes": "^2.3.0",
@@ -1341,9 +1385,9 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
@@ -1395,54 +1439,56 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.7.4.tgz",
-			"integrity": "sha512-ynT3o6md8AJU9z6+iKl/Jahuie8D/epQBC0PDa8UkLNHlY+5zECfVzpWDky5DwcZ/9+ckXoZxacuLkZU4bgSxg==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.13.1.tgz",
+			"integrity": "sha512-H0P9/0lNWcPvtb2lEioeZTfuwMlr19Wop8kwrjis1MFT1gDKLTM/NHvWgU6Vx1tXaDDgAyBdQx/0x2SrvlSM4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-algorand": "4.7.4",
-				"@wormhole-foundation/sdk-algorand-core": "4.7.4",
-				"@wormhole-foundation/sdk-algorand-tokenbridge": "4.7.4",
-				"@wormhole-foundation/sdk-aptos": "4.7.4",
-				"@wormhole-foundation/sdk-aptos-cctp": "4.7.4",
-				"@wormhole-foundation/sdk-aptos-core": "4.7.4",
-				"@wormhole-foundation/sdk-aptos-tokenbridge": "4.7.4",
-				"@wormhole-foundation/sdk-base": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm-core": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm-ibc": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.7.4",
-				"@wormhole-foundation/sdk-definitions": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
-				"@wormhole-foundation/sdk-evm-cctp": "4.7.4",
-				"@wormhole-foundation/sdk-evm-core": "4.7.4",
-				"@wormhole-foundation/sdk-evm-portico": "4.7.4",
-				"@wormhole-foundation/sdk-evm-tbtc": "4.7.4",
-				"@wormhole-foundation/sdk-evm-tokenbridge": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4",
-				"@wormhole-foundation/sdk-solana-cctp": "4.7.4",
-				"@wormhole-foundation/sdk-solana-core": "4.7.4",
-				"@wormhole-foundation/sdk-solana-tbtc": "4.7.4",
-				"@wormhole-foundation/sdk-solana-tokenbridge": "4.7.4",
-				"@wormhole-foundation/sdk-stacks": "4.7.4",
-				"@wormhole-foundation/sdk-stacks-core": "4.7.4",
-				"@wormhole-foundation/sdk-sui": "4.7.4",
-				"@wormhole-foundation/sdk-sui-cctp": "4.7.4",
-				"@wormhole-foundation/sdk-sui-core": "4.7.4",
-				"@wormhole-foundation/sdk-sui-tokenbridge": "4.7.4"
+				"@wormhole-foundation/sdk-algorand": "4.13.1",
+				"@wormhole-foundation/sdk-algorand-core": "4.13.1",
+				"@wormhole-foundation/sdk-algorand-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-aptos": "4.13.1",
+				"@wormhole-foundation/sdk-aptos-cctp": "4.13.1",
+				"@wormhole-foundation/sdk-aptos-core": "4.13.1",
+				"@wormhole-foundation/sdk-aptos-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-base": "4.13.1",
+				"@wormhole-foundation/sdk-btc": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm-ibc": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-definitions": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
+				"@wormhole-foundation/sdk-evm-cctp": "4.13.1",
+				"@wormhole-foundation/sdk-evm-core": "4.13.1",
+				"@wormhole-foundation/sdk-evm-portico": "4.13.1",
+				"@wormhole-foundation/sdk-evm-tbtc": "4.13.1",
+				"@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1",
+				"@wormhole-foundation/sdk-solana-cctp": "4.13.1",
+				"@wormhole-foundation/sdk-solana-core": "4.13.1",
+				"@wormhole-foundation/sdk-solana-tbtc": "4.13.1",
+				"@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-stacks": "4.13.1",
+				"@wormhole-foundation/sdk-stacks-core": "4.13.1",
+				"@wormhole-foundation/sdk-sui": "4.13.1",
+				"@wormhole-foundation/sdk-sui-cctp": "4.13.1",
+				"@wormhole-foundation/sdk-sui-core": "4.13.1",
+				"@wormhole-foundation/sdk-sui-tokenbridge": "4.13.1",
+				"@wormhole-foundation/sdk-xrpl": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-algorand": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.7.4.tgz",
-			"integrity": "sha512-CnDAQ1t+7ZTP+3QzjDSdPDVclSdu/i4dE/eX5wePv8U7R6RkXEKP/fbtY8aGp3SDtP0x5pT64eNrNOCc9Yut4Q==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.13.1.tgz",
+			"integrity": "sha512-E7ZItZrddQ8yOUG3rPJ2J4U0Gs9VfzYQ1Omx5Mv8nYxzSbGxU7/au8yZ++iTJNUH5S6jmJHCrkkvBikgE0d45g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
 				"algosdk": "2.7.0"
 			},
 			"engines": {
@@ -1450,89 +1496,89 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-algorand-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.7.4.tgz",
-			"integrity": "sha512-EXeEkdb5Hm+M/fY8frjiakWpcXTepPTvgTMIAhQL4kQIhNbAanr0ToXGkaamruNHMbDd6tlXZJD8sSekkMWVIA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.13.1.tgz",
+			"integrity": "sha512-y9I3Jt3AsTVbBNbO2Pd9LKQnlaG1/etzKi6Se2bcOS9JlD/muILKubLhmafLgqi13OUQb7bfdlARrfI7/dXW9A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-algorand": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-algorand": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-OSiMX41u39oDg041fz3wB/CZqhpA3Y6TnULjxbpJqZe6C51LNTnLHxxy63yoiPo1rKP7PErukmaDVSN48Ax8SQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-1VEcWdb9khdbD8fl2FlD4285cYzR3XkaZNyfbU+1qtmQ4Us+Xyjg138ESHO/2E+MRaVCtfi0lNvzvhbKs+LkYg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-algorand": "4.7.4",
-				"@wormhole-foundation/sdk-algorand-core": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-algorand": "4.13.1",
+				"@wormhole-foundation/sdk-algorand-core": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-aptos": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.7.4.tgz",
-			"integrity": "sha512-8q2E09JF+9ZKEbb4MzbkOH3wZwl8sdA4WRtiFxZvu9gaUHz8D0laTBkfcHdHZbFogV0pkK9DUm4g4lRIkZFMkQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.13.1.tgz",
+			"integrity": "sha512-7U04rkmhwvZts26hGiROblNazKKI+W30p4UHdiHg5Tiqql9tEj05xGaH2zHhWzg5vd8W4IPBFA79JfeKclQvtA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aptos-labs/ts-sdk": "^2.0.0",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.7.4.tgz",
-			"integrity": "sha512-sm1CX3PtkjN7P4uqbSwYxZI/z1zNZTmkhbCH5PTbpu1mlHld2FNrWfYAcK92edfHwBs/p4ZS6IrdhsrPs7vYAw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.13.1.tgz",
+			"integrity": "sha512-k+GU8ti4q5umq8iVW8mv6wLXHRd7PuGfT1Jo9i5EYcamq2+fx9z0TVQIgKUajYhc3nxin5VKcxnqYKCWt4xGYQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aptos-labs/ts-sdk": "^2.0.0",
-				"@wormhole-foundation/sdk-aptos": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-aptos": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-aptos-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.7.4.tgz",
-			"integrity": "sha512-iaeAyTW7NdGSJRUvSZKJOLdm8eKux7F78fRgud+nKIKbzsb9uCS0AlRSvBrhvB9eRFOTf5qUTcQhh+S06hGdwA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.13.1.tgz",
+			"integrity": "sha512-UvIB9DmtTHQ8/SkwOiDvHodyozO12vNHq8zydS0K6AB3UUcdjoThqvjhMCGE68wkvipsnHZ9jKWlsZcDQuvY1w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-aptos": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-aptos": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-Tn+Os/JIIPPkMDsyU6/IXcY2wCTONHJBP36m06Rx5VHF39liNNfAirGMttwcwjTkCZ2gg+N69fkkHtkSpgv3GA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-3moAOYLUjisuhIn8pErd+GneWZibMZmU18XfXogynAKyYB2kglG+Gmh7uz6aXhA2ePk8k/K59IrmJ05weTPBqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-aptos": "4.7.4",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-aptos": "4.13.1",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-base": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.8.0.tgz",
-			"integrity": "sha512-DMFey8KLyIOkfeo7GQj410mhY4oZ+j5HfZnEtUw4bQoifaeNyDAMDrFdDaOjGXir4z8r6+gRcWH6Zc6WX4DrAg==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.13.1.tgz",
+			"integrity": "sha512-oXZ3Dj7DlnhdHlAfMa4TAMTWRy7nz/FU7hT1/9Nl2v0TwTl2UX2U7u266sboEb4C6damMcMRjXR2P5hDcytw4w==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -1540,14 +1586,26 @@
 				"binary-layout": "^1.0.3"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-connect": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.7.4.tgz",
-			"integrity": "sha512-YEQ7gSk6k9USyzKtPf3X7IojrAepHwUvSPaZeMT+xKCKJYpJ/ot3iS7bnY9MUhuaRd0RxBJbYE3Ys1fBzZTBFQ==",
+		"node_modules/@wormhole-foundation/sdk-btc": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-btc/-/sdk-btc-4.13.1.tgz",
+			"integrity": "sha512-5psm/56XIj5z8A69xCekX490qSByGKM/2tM7Dq3wlynNi81XqS9onYOJP63TQn4SG7ZVpeaJTDSbUDuOraPHaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-base": "4.7.4",
-				"@wormhole-foundation/sdk-definitions": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@wormhole-foundation/sdk-connect": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.13.1.tgz",
+			"integrity": "sha512-ZAgoWGIJ4CXCvu01TaBRSZz5rxMpV8DpCbvkun5y9+aZkvsOuV98R3Se3gglpXQYc7kTrbWagjmFo2xsOXOplA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@wormhole-foundation/sdk-base": "4.13.1",
+				"@wormhole-foundation/sdk-definitions": "4.13.1",
 				"axios": "^1.4.0"
 			},
 			"engines": {
@@ -1555,16 +1613,16 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-cosmwasm": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.7.4.tgz",
-			"integrity": "sha512-hU4JD3cr3acZmI0BP/BZliqPwN4yD4Mk/noW+vbmi3SMkUigm983F8Qdt7+d+MIDW6zHDDQdzVaMF7Cl6WT7Ug==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.13.1.tgz",
+			"integrity": "sha512-NQaSmMeZEwf6h6NYS638DC8RfMzEvAEt8b/a/YvD5HME+ILRrKh9iLEbwboHENDHhYGC03msDJfrXga1hnuydQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cosmjs/cosmwasm-stargate": "^0.32.0",
 				"@cosmjs/proto-signing": "^0.32.0",
 				"@cosmjs/stargate": "^0.32.0",
 				"@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
 				"cosmjs-types": "^0.9.0"
 			},
 			"engines": {
@@ -1572,33 +1630,33 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.7.4.tgz",
-			"integrity": "sha512-KUlur5EnpYz+K12RODqY/i3B4SThMJgRN8YUfNpkaUrxnPpCofi4b6f6akvp1n+ns6KsxD9N45Fa8pZ/1K6Dsw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.13.1.tgz",
+			"integrity": "sha512-8614HBvVMLa90eeW2kDzMWAPHVXibEjgrel7k7N/Kszq/C+8pUimtDXd+4JW5eMuYr8H/6xVxcsKludxHRu0NA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cosmjs/cosmwasm-stargate": "^0.32.0",
 				"@cosmjs/stargate": "^0.32.0",
 				"@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.7.4.tgz",
-			"integrity": "sha512-Vaq3F/GSOxhNsPTIwoFgjY+6hLmoWw2apvF3PcHwecosdASA3E7ZaehB1saQgwe63r286dqikPTzcmL5fsVysQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.13.1.tgz",
+			"integrity": "sha512-IwjbPgFcsJg51Iex1ntahRzflBhWNVyQiRsIijkhtsSY6tmuwNmIDr8Q9M/Kd2/eRRAWlZNCYPh8kgwt1Za0Xw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cosmjs/cosmwasm-stargate": "^0.32.0",
 				"@cosmjs/stargate": "^0.32.0",
 				"@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm-core": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
 				"cosmjs-types": "^0.9.0"
 			},
 			"engines": {
@@ -1606,47 +1664,47 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-EDxfS8iZpAvNuprOPaRG2UKFj8kQya2IZ4Ys7rMcT7RlbdKWoaE9OqzuS3Lq3laI+EOtXwLg2yLQixHhVdhLlw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-LB1QP0IYvBKNXeQrhYnr8wBc2SE6zwcMaqG6Wy5B8/CWY9tHDL3iK9x1Z2AfB/QENgFyc+U1VI5z9a0LkFEChg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cosmjs/cosmwasm-stargate": "^0.32.0",
 				"@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-cosmwasm": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-cosmwasm": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-definitions": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.8.0.tgz",
-			"integrity": "sha512-C/mo5jaZJ3ZrO9pUCf/oYdpwLMRPCkiMfC52v/LUfRk+RVXTC+CPwZvIGlW4JkXcCcyltGsV4AP1pnoCqOolgQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.13.1.tgz",
+			"integrity": "sha512-/8X1q8zgmPTnjql5aoARpZ4jhdYSccx6pFLboVoJIPUSszSWDaMgUvGX2039mCp7KPGdV8SNMVrAPtR47ipZFA==",
 			"peer": true,
 			"dependencies": {
 				"@noble/curves": "^1.4.0",
 				"@noble/hashes": "^1.3.1",
-				"@wormhole-foundation/sdk-base": "4.8.0"
+				"@wormhole-foundation/sdk-base": "4.13.1"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-definitions-ntt": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-4.0.10.tgz",
-			"integrity": "sha512-IA8XUVnO+V6F5gUjmbXMe9W0Z99JngLAq+AgAGFkptlgXb7zlYJ9Hx6Pi33F6DvnMOl/3Y5aisqw7amP7d7Aew==",
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-4.0.16.tgz",
+			"integrity": "sha512-Tl8ApzU/hsN+smdyPkROq030C0qIEw8SvOc+k+yDsXw0Ef0uW7v00HXVFA1ijkATCrPM1Apme3txnJPEZkQ+8Q==",
 			"peerDependencies": {
-				"@wormhole-foundation/sdk-base": "^4.7.0",
-				"@wormhole-foundation/sdk-definitions": "^4.7.0"
+				"@wormhole-foundation/sdk-base": "^4.10.0",
+				"@wormhole-foundation/sdk-definitions": "^4.10.0"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.7.4.tgz",
-			"integrity": "sha512-nV3AtbbAEwlOrwtWCDMLZobKLpV+vVvdv619WsLIkSp5w7d48ngjlmHWZL0WOgjXvfgNtD7gy3AtnsteabQJ6g==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.13.1.tgz",
+			"integrity": "sha512-24jrp8cH9Nlc1laN/TGihOiGkUjlYFVUNhXklHlsmCuzP0G9/mJKde2k9y/4u8qsgI/d3YxRAVscxADez4NqFw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1654,14 +1712,14 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm-cctp": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.7.4.tgz",
-			"integrity": "sha512-NfBltTdldq+qExpFNQZDG6WqIw43UUDPPdKfHyuclWi0wgfi1nOAfqM8v3mZE6mTLWcw94wHje6YfY4mJsPsZg==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.13.1.tgz",
+			"integrity": "sha512-XWtj6Oj56wL9UDGi1kU1FW6g1lcHNdaYBl9aSTMKOQU/kaEYZA4gEJ0gF5n9v2To+ZD7pGq6NRXQOiXYrzgjqg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
-				"@wormhole-foundation/sdk-evm-core": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
+				"@wormhole-foundation/sdk-evm-core": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1669,13 +1727,13 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.7.4.tgz",
-			"integrity": "sha512-mcAnZL0fY+XbY9uSjVq14hhCXNBfw+a+O3/ZNABBgS/5jh8/i7DQRz0fbVvk8xrOCdLWEtdneRCXC4beVTE6YA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.13.1.tgz",
+			"integrity": "sha512-r/FGJYx6r1bhkO29GPG2c0QN0Oy2K+07g2idUWt2RdHWYlkDXgWQmtA04eKgyU5O5jPkXguJu8mA4lrXfyOUMg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1683,15 +1741,15 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm-portico": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.7.4.tgz",
-			"integrity": "sha512-E9Jwbz8g9WhcNBMNuZsdypJ2PCqN367x1G+r5ur7ft6Imq5HNHlgCakm2NwruUfepyAqiAZVPmPSFRDnGirEGw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.13.1.tgz",
+			"integrity": "sha512-Hs0slWmdcn74nzS3vlaNNPE38opaZew9CvMi476YdOCv6UNUIMTqQiYbJERTiI7X9d7BS+w3CVmORg5njMkwww==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
-				"@wormhole-foundation/sdk-evm-core": "4.7.4",
-				"@wormhole-foundation/sdk-evm-tokenbridge": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
+				"@wormhole-foundation/sdk-evm-core": "4.13.1",
+				"@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1699,14 +1757,14 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.7.4.tgz",
-			"integrity": "sha512-9Sc/P9fue2nn5240bD90eSdgAzT3cYXlW8YG6638eYrMAxhtL32cuMTaH+8m0PIqAlAfWMD2QzBSP7zEO8x4tw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.13.1.tgz",
+			"integrity": "sha512-tj7Ak8m/F3t/B5iWTYGuOMWvSGuum6G1su/NX9w1q3FJvfDRnQXwsZVyw/byCRY7Ovd80PNFNnJlHo1/wpPE9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
-				"@wormhole-foundation/sdk-evm-core": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
+				"@wormhole-foundation/sdk-evm-core": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1714,14 +1772,14 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-1IVDRxamQIH5Clk97Cva+B6yuuDO1zDmry2zZFfjuq8ThWU+Qgf3IjFUrJzQGfzJPIIk8VmuvfObKwsSIEioKA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-ctHwgjhC4k9YpSPPwbtvrifmI8gPr2rHsTS9yol5c1iHXKuaYV8TSyFJbJriRYb31Mf8sqeODSDHfTNSrz2GUQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-evm": "4.7.4",
-				"@wormhole-foundation/sdk-evm-core": "4.7.4",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-evm": "4.13.1",
+				"@wormhole-foundation/sdk-evm-core": "4.13.1",
 				"ethers": "^6.5.1"
 			},
 			"engines": {
@@ -1729,16 +1787,16 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.8.0.tgz",
-			"integrity": "sha512-0q9avAIEJw/ha8jofUaUKoFVyieb7IdjfWkKaUb2FqTEqhe/vWBEde3GcWtq7Xx98UlzJ1Cb6N5tKsVT42AWDg==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.13.1.tgz",
+			"integrity": "sha512-9gV8qQaEXHYd+WbCx9wn1ZcPslfKGAewV06llrtaLPCTGq1vPA0lPPyeNeEwwrIHsv8aNFABF+Vm17eKWnK1TA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@coral-xyz/borsh": "0.29.0",
 				"@solana/spl-token": "0.3.9",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.8.0",
+				"@wormhole-foundation/sdk-connect": "4.13.1",
 				"rpc-websockets": "^7.10.0"
 			},
 			"engines": {
@@ -1746,16 +1804,16 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana-cctp": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.7.4.tgz",
-			"integrity": "sha512-80B6ILpE3MOC11Bk+VcTtCQwEu50vuPUTZRuDH4crifCISgiCRUrfa1+QlY/2KjJUiv/tJsF2KB/2a5L84xPvQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.13.1.tgz",
+			"integrity": "sha512-N7jGhD3Fwt9ZKBgx01YOGKPJJyU9jmgP+GdyBG8LVFWhmki1VcKAs7AoijYyWmsUcuSjI2PuvmRvc3wLP0K8aQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@solana/spl-token": "0.3.9",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -1819,23 +1877,6 @@
 				"@solana/web3.js": "^1.47.4"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/@wormhole-foundation/sdk-solana": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.7.4.tgz",
-			"integrity": "sha512-iJWmiKDlEkbzpKc539HbHxRHJS8Qp3MECNpEFItHysvRwtsB/SiU73yt+GWk/L3LNIMgp9PO5RYVK4DNS8345A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/spl-token": "0.3.9",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"rpc-websockets": "^7.10.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/base-x": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -1854,57 +1895,17 @@
 				"base-x": "^3.0.2"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/rpc-websockets": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-			"integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-			"license": "LGPL-3.0-only",
-			"dependencies": {
-				"eventemitter3": "^4.0.7",
-				"uuid": "^8.3.2",
-				"ws": "^8.5.0"
-			},
-			"funding": {
-				"type": "paypal",
-				"url": "https://paypal.me/kozjak"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-core": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.8.0.tgz",
-			"integrity": "sha512-jrYoeJXQfMwRl2xl8JfU2MD2fJQpQIIiDYlZ8TWjFEZEVz7sbraPBmaBlEpUse5++g2s10OUo+73MDUbXznHJg==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.13.1.tgz",
+			"integrity": "sha512-gcOvdKxMip2uKcgOHgUNH4NuWkw65XPC4hCn84COoglTx0NCQ4XfZARSy16Q14CzQqh/J+xSIpdFk7ER22oB0w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@coral-xyz/borsh": "0.29.0",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.8.0",
-				"@wormhole-foundation/sdk-solana": "4.8.0"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -1951,20 +1952,6 @@
 				"@solana/web3.js": "^1.68.0"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-core/node_modules/@wormhole-foundation/sdk-connect": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.8.0.tgz",
-			"integrity": "sha512-2UqV/nwbdBaQ4f5tcy32+kumFziYT6jGvfmpRkF5ueHVGSTuoumk4WUjvm3k5BIEUzCTgIN3Qhs2fNlkKwdpow==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@wormhole-foundation/sdk-base": "4.8.0",
-				"@wormhole-foundation/sdk-definitions": "4.8.0",
-				"axios": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-core/node_modules/base-x": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -1984,26 +1971,26 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana-ntt": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-4.0.10.tgz",
-			"integrity": "sha512-iEap23R4iqNoPyzqrG3e0mZysOi/4S8aoOGMX/7Oj69P04CntR/JPPYszfeIlSuAG+y32JgYJfbyi0fFN5OZgg==",
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-4.0.16.tgz",
+			"integrity": "sha512-fHRKMPTuK0s6vYVREeMBPkB6dZbqOafjQ81rSv9V1JCFsD+VYdslPSPoRhZMYKuUpNiOXZRXKXfipdQ6GGyqmQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@coral-xyz/borsh": "0.29.0",
 				"@solana/spl-token": "0.4.0",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-definitions-ntt": "4.0.10",
+				"@wormhole-foundation/sdk-definitions-ntt": "4.0.16",
 				"bn.js": "5.2.1"
 			},
 			"engines": {
 				"node": ">=16"
 			},
 			"peerDependencies": {
-				"@wormhole-foundation/sdk-base": "^4.7.0",
-				"@wormhole-foundation/sdk-definitions": "^4.7.0",
-				"@wormhole-foundation/sdk-solana": "^4.7.0",
-				"@wormhole-foundation/sdk-solana-core": "^4.7.0"
+				"@wormhole-foundation/sdk-base": "^4.10.0",
+				"@wormhole-foundation/sdk-definitions": "^4.10.0",
+				"@wormhole-foundation/sdk-solana": "^4.10.0",
+				"@wormhole-foundation/sdk-solana-core": "^4.10.0"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana-ntt/node_modules/@coral-xyz/anchor": {
@@ -2090,18 +2077,18 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.7.4.tgz",
-			"integrity": "sha512-fT1c2oIslcvfSBtw02uAzXM7886s9W573w/l4uBHbFbICxMzE2uupwHJQLW8xlk8UjKY1VmPXoW6a25POJwEiA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.13.1.tgz",
+			"integrity": "sha512-LrqmizRQ7wMstOudGDG/5Bhoeafy9fCk4Fsid/NQ3XKuY+ckvHR9HJUIEvG9Gi/8SdQ3+my8qyXoRAYap7AkpA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@solana/spl-token": "0.3.9",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4",
-				"@wormhole-foundation/sdk-solana-core": "4.7.4",
-				"@wormhole-foundation/sdk-solana-tokenbridge": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1",
+				"@wormhole-foundation/sdk-solana-core": "4.13.1",
+				"@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -2165,39 +2152,6 @@
 				"@solana/web3.js": "^1.47.4"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-tbtc/node_modules/@wormhole-foundation/sdk-solana": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.7.4.tgz",
-			"integrity": "sha512-iJWmiKDlEkbzpKc539HbHxRHJS8Qp3MECNpEFItHysvRwtsB/SiU73yt+GWk/L3LNIMgp9PO5RYVK4DNS8345A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/spl-token": "0.3.9",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"rpc-websockets": "^7.10.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-tbtc/node_modules/@wormhole-foundation/sdk-solana-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.7.4.tgz",
-			"integrity": "sha512-3NYHuIqmEdDswp+7TxJRJKTni5Yuc+Y9vHDq8fqBMaPRzpBc6NiZpvrVLuEF4/rHlfXUPlHcUh260yEc6K/SUQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-tbtc/node_modules/base-x": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -2216,58 +2170,18 @@
 				"base-x": "^3.0.2"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-tbtc/node_modules/rpc-websockets": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-			"integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-			"license": "LGPL-3.0-only",
-			"dependencies": {
-				"eventemitter3": "^4.0.7",
-				"uuid": "^8.3.2",
-				"ws": "^8.5.0"
-			},
-			"funding": {
-				"type": "paypal",
-				"url": "https://paypal.me/kozjak"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-tbtc/node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-OWEDmZCvhsicfxGbNGfzQX+0jz8qkWsGba0tBa4AdjBkihG7bz2U6omrmzM+VvBqlmfJYgpoL8DQTTcjqNYOeA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-jhMVoPxQhmwqvdovqGcZ704+5+ajdRkr+tS6qOZeCwHK6wyBwYjS9sMGRiMyDKuOA2CZ0HpDU4BP6lmzGpd3wg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@coral-xyz/anchor": "0.29.0",
 				"@solana/spl-token": "0.3.9",
 				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4",
-				"@wormhole-foundation/sdk-solana-core": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-solana": "4.13.1",
+				"@wormhole-foundation/sdk-solana-core": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -2331,39 +2245,6 @@
 				"@solana/web3.js": "^1.47.4"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/@wormhole-foundation/sdk-solana": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.7.4.tgz",
-			"integrity": "sha512-iJWmiKDlEkbzpKc539HbHxRHJS8Qp3MECNpEFItHysvRwtsB/SiU73yt+GWk/L3LNIMgp9PO5RYVK4DNS8345A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/spl-token": "0.3.9",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"rpc-websockets": "^7.10.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/@wormhole-foundation/sdk-solana-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.7.4.tgz",
-			"integrity": "sha512-3NYHuIqmEdDswp+7TxJRJKTni5Yuc+Y9vHDq8fqBMaPRzpBc6NiZpvrVLuEF4/rHlfXUPlHcUh260yEc6K/SUQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/base-x": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -2380,46 +2261,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"base-x": "^3.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/rpc-websockets": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-			"integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-			"license": "LGPL-3.0-only",
-			"dependencies": {
-				"eventemitter3": "^4.0.7",
-				"uuid": "^8.3.2",
-				"ws": "^8.5.0"
-			},
-			"funding": {
-				"type": "paypal",
-				"url": "https://paypal.me/kozjak"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana/node_modules/@coral-xyz/anchor": {
@@ -2478,20 +2319,6 @@
 			},
 			"peerDependencies": {
 				"@solana/web3.js": "^1.47.4"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk-solana/node_modules/@wormhole-foundation/sdk-connect": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.8.0.tgz",
-			"integrity": "sha512-2UqV/nwbdBaQ4f5tcy32+kumFziYT6jGvfmpRkF5ueHVGSTuoumk4WUjvm3k5BIEUzCTgIN3Qhs2fNlkKwdpow==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@wormhole-foundation/sdk-base": "4.8.0",
-				"@wormhole-foundation/sdk-definitions": "4.8.0",
-				"axios": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-solana/node_modules/base-x": {
@@ -2553,217 +2380,122 @@
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-stacks": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.7.4.tgz",
-			"integrity": "sha512-r3p2+fqrEGajzK/Q7iAY/5TQ8IsC6BobQQc16/SLmn6W/9zJPxgtlkPaTAhFNmX4o130UgCyLqJAK2SphUHCSQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.13.1.tgz",
+			"integrity": "sha512-ptFhvojQgn/6v+0RMDHj7ti7gz22jiHEKrmtkrANj/PTQDRxzt7tk3w3pBOpClBuZLds/iLkpFyGVCuQKeiU/g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@stacks/network": "^7.0.2",
 				"@stacks/transactions": "^7.1.0",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-stacks-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.7.4.tgz",
-			"integrity": "sha512-XDCBTWxPRRWd2bRjdt8TxmbErCNbIDaUa38ZXELRquY+L9fPQkQLQfxMtuYpKlkFxFlSfO8HtxtF8nNMB6FuGw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.13.1.tgz",
+			"integrity": "sha512-ABdTqKkTELiabyLDX1hNDdpFBw15igOPECVw5jqT9VyzVOZQoqJYIB2RASqDWWN0eqVenKmraYdiCh8z0pjKLA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-stacks": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-stacks": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-sui": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.7.4.tgz",
-			"integrity": "sha512-eN2SW1G4nW8uwRRk1Ocd5d+yh+/H3tdFfrgWUjXx3q/i+4N2V7UNC3xpeZTd4TFBH0+JVjq+FPWv16dDqy1SEQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.13.1.tgz",
+			"integrity": "sha512-GHXSrx6LTLjsqVrNvmvT3Tq6DbSuvsG5MvSlPC7MLC/W0cTVsm2dq5h0lbswLc66WzM4y0AT7knlo+hZL0aTIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mysten/sui": "^1.37.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-sui-cctp": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.7.4.tgz",
-			"integrity": "sha512-eTKJZMW3q7fF3p8ioFelaD0HsfCBBp/PCfh/hu7i/eLuFomlZ8fwZ8sV5npcHXw42GsXa3pNaFxkErEutsYPBQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.13.1.tgz",
+			"integrity": "sha512-4SF/tCqPQxK8wnGQmFl28sqt8HdHm5nBCZYeVI+bdtz8KcnBt4B7viG3DQ2T14eqdpVlTc+6GhggDqNx8kMtSA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mysten/sui": "^1.37.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-sui": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-sui": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-sui-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.7.4.tgz",
-			"integrity": "sha512-jCO+L2SrcMmVlzX1xl27MV5Z7Q1iU7YCfn3YHm84c8T788lsenPGopqdxNMyFZEifVjhxqHu5hTdzAejmqXt1g==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.13.1.tgz",
+			"integrity": "sha512-lFR0IuO0EJssv3bJ1+lB+2x+QkOt96md5G+lt/Qbeq2WUEOnk9LTu35oVXdHI9Njzv3Z0JkxPvRzjDuOYkWU4A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mysten/sui": "^1.37.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-sui": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-sui": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.7.4.tgz",
-			"integrity": "sha512-TbGK/vp/jlDlIqkcoVnJlWZA+f9KrQZljcjKU4tlkgKOCPqzuwZyXJpK56CItEsVjbVu1MqJjTiZeYkiXOFGzA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.13.1.tgz",
+			"integrity": "sha512-0+h2TyTylUUiS3u9OephDlEUKy4XMWMqrzgeuM9znnxqZOlI+7ZfR5VJ82ucN1IygFdoikFDxmiPBTptSwJbxQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mysten/sui": "^1.37.2",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-sui": "4.7.4",
-				"@wormhole-foundation/sdk-sui-core": "4.7.4"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"@wormhole-foundation/sdk-sui": "4.13.1",
+				"@wormhole-foundation/sdk-sui-core": "4.13.1"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/@coral-xyz/anchor": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
-			"integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
-			"license": "(MIT OR Apache-2.0)",
-			"dependencies": {
-				"@coral-xyz/borsh": "^0.29.0",
-				"@noble/hashes": "^1.3.1",
-				"@solana/web3.js": "^1.68.0",
-				"bn.js": "^5.1.2",
-				"bs58": "^4.0.1",
-				"buffer-layout": "^1.2.2",
-				"camelcase": "^6.3.0",
-				"cross-fetch": "^3.1.5",
-				"crypto-hash": "^1.3.0",
-				"eventemitter3": "^4.0.7",
-				"pako": "^2.0.3",
-				"snake-case": "^3.0.4",
-				"superstruct": "^0.15.4",
-				"toml": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=11"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/@coral-xyz/borsh": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
-			"integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+		"node_modules/@wormhole-foundation/sdk-xrpl": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-xrpl/-/sdk-xrpl-4.13.1.tgz",
+			"integrity": "sha512-4JbcVCx8Kqxqn/1Ytugf+J4IduJ0TRdLbdupIIG9mkcIJDvuqYY0/n7apv4tKKwCAQRsQEPF3QaIDeCnSvukhg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"bn.js": "^5.1.2",
-				"buffer-layout": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@solana/web3.js": "^1.68.0"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/@solana/spl-token": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
-			"integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@solana/buffer-layout": "^4.0.0",
-				"@solana/buffer-layout-utils": "^0.2.0",
-				"buffer": "^6.0.3"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"@solana/web3.js": "^1.47.4"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-solana": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.7.4.tgz",
-			"integrity": "sha512-iJWmiKDlEkbzpKc539HbHxRHJS8Qp3MECNpEFItHysvRwtsB/SiU73yt+GWk/L3LNIMgp9PO5RYVK4DNS8345A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/spl-token": "0.3.9",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"rpc-websockets": "^7.10.0"
+				"@wormhole-foundation/sdk-connect": "4.13.1",
+				"xrpl": "^4.2.0"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-solana-core": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.7.4.tgz",
-			"integrity": "sha512-3NYHuIqmEdDswp+7TxJRJKTni5Yuc+Y9vHDq8fqBMaPRzpBc6NiZpvrVLuEF4/rHlfXUPlHcUh260yEc6K/SUQ==",
-			"license": "Apache-2.0",
+		"node_modules/@xrplf/isomorphic": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.1.tgz",
+			"integrity": "sha512-0bIpgx8PDjYdrLFeC3csF305QQ1L7sxaWnL5y71mCvhenZzJgku9QsA+9QCXBC1eNYtxWO/xR91zrXJy2T/ixg==",
+			"license": "ISC",
 			"dependencies": {
-				"@coral-xyz/anchor": "0.29.0",
-				"@coral-xyz/borsh": "0.29.0",
-				"@solana/web3.js": "^1.95.8",
-				"@wormhole-foundation/sdk-connect": "4.7.4",
-				"@wormhole-foundation/sdk-solana": "4.7.4"
+				"@noble/hashes": "^1.0.0",
+				"eventemitter3": "5.0.1",
+				"ws": "^8.13.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/base-x": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-			"integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
+		"node_modules/@xrplf/isomorphic/node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"license": "MIT"
 		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-			"license": "MIT",
-			"dependencies": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/rpc-websockets": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-			"integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-			"license": "LGPL-3.0-only",
-			"dependencies": {
-				"eventemitter3": "^4.0.7",
-				"uuid": "^8.3.2",
-				"ws": "^8.5.0"
-			},
-			"funding": {
-				"type": "paypal",
-				"url": "https://paypal.me/kozjak"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			}
-		},
-		"node_modules/@wormhole-foundation/sdk/node_modules/ws": {
+		"node_modules/@xrplf/isomorphic/node_modules/ws": {
 			"version": "8.19.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
 			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
@@ -2782,6 +2514,16 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@xrplf/secret-numbers": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+			"integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
+			"license": "ISC",
+			"dependencies": {
+				"@xrplf/isomorphic": "^1.0.1",
+				"ripple-keypairs": "^2.0.0"
 			}
 		},
 		"node_modules/abitype": {
@@ -2859,13 +2601,13 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.13.3",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
-			"integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -3025,21 +2767,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.5"
-			}
-		},
-		"node_modules/bufferutil": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
 			}
 		},
 		"node_modules/c32check": {
@@ -3328,9 +3055,9 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
@@ -3488,6 +3215,12 @@
 			"engines": {
 				"node": "> 0.1.90"
 			}
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"license": "MIT"
 		},
 		"node_modules/fast-stable-stringify": {
 			"version": "1.0.0",
@@ -3686,9 +3419,9 @@
 			}
 		},
 		"node_modules/graphql": {
-			"version": "16.12.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-			"integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
+			"integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4145,9 +3878,9 @@
 			}
 		},
 		"node_modules/ox": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
-			"integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
+			"integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
 			"funding": [
 				{
 					"type": "github",
@@ -4255,9 +3988,9 @@
 			"license": "MIT"
 		},
 		"node_modules/pump": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -4298,6 +4031,47 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ripple-address-codec": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.0.tgz",
+			"integrity": "sha512-de7osLRH/pt5HX2xw2TRJtbdLLWHu0RXirpQaEeCnWKY5DYHykh3ETSkofvm0aX0LJiV7kwkegJxQkmbO94gWw==",
+			"license": "ISC",
+			"dependencies": {
+				"@scure/base": "^1.1.3",
+				"@xrplf/isomorphic": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/ripple-binary-codec": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.7.0.tgz",
+			"integrity": "sha512-gEBqan5muVp+q7jgZ6aUniSyN+e4FKRzn9uFAeFSIW7IgvkezP1cUolNtpahQ+jvaSK/33hxZA7wNmn1mc330g==",
+			"license": "ISC",
+			"dependencies": {
+				"@xrplf/isomorphic": "^1.0.1",
+				"bignumber.js": "^9.0.0",
+				"ripple-address-codec": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/ripple-keypairs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
+			"integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
+			"license": "ISC",
+			"dependencies": {
+				"@noble/curves": "^1.0.0",
+				"@xrplf/isomorphic": "^1.0.0",
+				"ripple-address-codec": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/rpc-websockets": {
@@ -4509,21 +4283,6 @@
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"license": "MIT"
 		},
-		"node_modules/utf-8-validate": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4548,9 +4307,9 @@
 			}
 		},
 		"node_modules/viem": {
-			"version": "2.45.0",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.45.0.tgz",
-			"integrity": "sha512-iVA9qrAgRdtpWa80lCZ6Jri6XzmLOwwA1wagX2HnKejKeliFLpON0KOdyfqvcy+gUpBVP59LBxP2aKiL3aj8fg==",
+			"version": "2.47.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.47.2.tgz",
+			"integrity": "sha512-etDIwDgmDiGaPg8rUbJtUFuC3/nAJCbhMYyfh5dOcqNNkzBWTNcS2VluPSM5JVo+9U3b2hle2RkBEq3+xyvlvg==",
 			"funding": [
 				{
 					"type": "github",
@@ -4565,7 +4324,7 @@
 				"@scure/bip39": "1.6.0",
 				"abitype": "1.2.3",
 				"isows": "1.0.7",
-				"ox": "0.11.3",
+				"ox": "0.14.0",
 				"ws": "8.18.3"
 			},
 			"peerDependencies": {
@@ -4662,6 +4421,33 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/xrpl": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.6.0.tgz",
+			"integrity": "sha512-0nXZfqDHRJ6bsDv1WtA9MdCYalMtXuxVa9mtLdqT3xypRKf2LwT5DbuGL/kHcVfuqk3B+ly+SFARlrnX+LHtRQ==",
+			"license": "ISC",
+			"dependencies": {
+				"@scure/bip32": "^1.3.1",
+				"@scure/bip39": "^1.2.1",
+				"@xrplf/isomorphic": "^1.0.1",
+				"@xrplf/secret-numbers": "^2.0.0",
+				"bignumber.js": "^9.0.0",
+				"eventemitter3": "^5.0.1",
+				"fast-json-stable-stringify": "^2.1.0",
+				"ripple-address-codec": "^5.0.0",
+				"ripple-binary-codec": "^2.7.0",
+				"ripple-keypairs": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/xrpl/node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"license": "MIT"
 		},
 		"node_modules/xstream": {
 			"version": "11.14.0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
 		"@solana-developers/helpers": "^2.8.0",
 		"@solana/spl-token": "^0.4.13",
 		"@solana/web3.js": "^1.98.0",
-		"@wormhole-foundation/sdk": "4.7.4",
-		"@wormhole-foundation/sdk-solana": "4.8.0",
-		"@wormhole-foundation/sdk-solana-ntt": "4.0.10",
+		"@wormhole-foundation/sdk": "4.13.1",
+		"@wormhole-foundation/sdk-solana": "4.13.1",
+		"@wormhole-foundation/sdk-solana-ntt": "4.0.16",
 		"dotenv": "^16.4.7"
 	},
 	"overrides": {
-		"@wormhole-foundation/sdk-base": "4.8.0",
-		"@wormhole-foundation/sdk-definitions": "4.8.0"
+		"@wormhole-foundation/sdk-base": "4.13.1",
+		"@wormhole-foundation/sdk-definitions": "4.13.1"
 	},
 	"devDependencies": {
 		"typescript": "^5.8.3"


### PR DESCRIPTION
## Summary
- Bump `@wormhole-foundation/sdk`, `sdk-solana`, `sdk-base`, `sdk-definitions` from 4.7.4–4.8.0 → **4.13.1**
- Bump `@wormhole-foundation/sdk-solana-ntt` from 4.0.10 → **4.0.16**
- Add `versioning-strategy: increase` to dependabot config to prevent version drift
- Add dependabot grouping for `@wormhole-foundation/sdk-*-ntt` packages

Supersedes #111, #114, #115 — those PRs can be closed after merging this one.

## Test plan
- [x] `npm run typecheck` passes